### PR TITLE
PropTypes Fix

### DIFF
--- a/native/src/components/MidiTrack.js
+++ b/native/src/components/MidiTrack.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import MidiIO from '../MidiIO/src/';


### PR DESCRIPTION
Attempting to get rid of "undefined is not an object (evaluating PropTypes)" error