### PR TITLE
#3 Fix undefined prop types

### DIFF
--- a/native/src/components/MidiTrack.js
+++ b/native/src/components/MidiTrack.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
+import { View, ViewPropTypes } from 'react-native';
 
 import MidiIO from '../MidiIO/src/';
 import Note from './Note';
@@ -142,7 +142,7 @@ MidiTrack.propTypes = {
       instrumentName: PropTypes.string,
       deltaTime: PropTypes.number,
       msPerTick: PropTypes.number,
-      style: View.propTypes.style,
+      style: ViewPropTypes.style,
     },
   )),
 };

--- a/native/src/components/Orchestra.js
+++ b/native/src/components/Orchestra.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 
 import MidiTrack from './MidiTrack';

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "midi-file-parser": "^1.0.0",
     "midi-writer-js": "^1.4.0",
     "pre-commit": "^1.2.2",
+    "prop-types": "^15.7.2",
     "react-keymaster": "^0.1.0",
     "soundfont-player": "^0.10.5"
   },


### PR DESCRIPTION
Fixes issue #3 and possibly #6 (as I'm running fine on react-native 0.61.5 with this patch).

`PropTypes` and `View.propTypes` have been extracted to seperate modules. Looks like a fix was previously started (#7) but missed a couple imports.